### PR TITLE
fix: set cors to `true` in serverless

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -6,6 +6,8 @@ provider:
   runtime: nodejs14.x
   region: us-west-1
   deploymentMethod: direct
+  httpApi:
+    cors: true
 
 functions:
   handler:


### PR DESCRIPTION
# Changes

- Fix the `POST` request in browsers by setting CORS to `true` in the serverless.yml.

### More Information

- https://www.serverless.com/blog/cors-api-gateway-survival-guide/
- https://www.serverless.com/framework/docs/providers/aws/events/http-api#cors-setup