### PR TITLE
feat: add validation for empty body

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ Using `fetch`:
 ```javascript
 fetch('http://localhost:3000/mortgage', {
   method: 'POST',
-      body: JSON.stringify({
-      propertyPrice: 600000,
-      downPayment: 200000,
-      nominalInterestRate: 4,
-      amortization: 25,
-      paymentSchedule: "monthly" 
+  body: JSON.stringify({
+    propertyPrice: 600000,
+    downPayment: 200000,
+    nominalInterestRate: 4,
+    amortization: 25,
+    paymentSchedule: "monthly" 
   }),
   headers: {
     'Content-type': 'application/json; charset=UTF-8'

--- a/handler.ts
+++ b/handler.ts
@@ -5,7 +5,8 @@ export const main: Handler = (event: any) => {
   let response: { statusCode: number; body: any; };
 
   if (event.requestContext.http.method === 'POST') {
-    const { propertyPrice, downPayment, nominalInterestRate, amortization, paymentSchedule } = JSON.parse(event.body);
+    const payload = event.body ? JSON.parse(event.body) : {};
+    const { propertyPrice, downPayment, nominalInterestRate, amortization, paymentSchedule } = payload;
     const mortgage = calculate(propertyPrice, downPayment, nominalInterestRate, amortization, paymentSchedule);
     
     response = (typeof mortgage === 'number')

--- a/src/validator.spec.ts
+++ b/src/validator.spec.ts
@@ -38,9 +38,9 @@ describe("Tests if an error is returned when the parameter is null, undefined, N
   });
 });
 
-describe("Tests if the down payment parameter is validated correctly", () => {
+describe("Tests if the down payment is validated correctly", () => {
   it("should return error if down payment is below the minimum", () => {
-    const { propertyPrice, nominalInterestRate, amortization, paymentSchedule} = defaultValues;
+    const { propertyPrice, nominalInterestRate, amortization, paymentSchedule } = defaultValues;
     const downPayment = 500;
 
     const errors = validate(propertyPrice, downPayment as any, nominalInterestRate, amortization, paymentSchedule);
@@ -48,5 +48,31 @@ describe("Tests if the down payment parameter is validated correctly", () => {
 
     const errorInfo = JSON.parse(errors[0].message).information;
     expect(errorInfo).toBe(`With a property price of "${propertyPrice}", the down payment must be at least 35000. "${downPayment}" was received instead.`);
+  });
+});
+
+describe("Tests if the payment schedule is validated correctly", () => {
+  it("should return error if payment schedule is invalid", () => {
+    const { propertyPrice, downPayment, nominalInterestRate, amortization } = defaultValues;
+    const paymentSchedule = "weekly";
+
+    const errors = validate(propertyPrice, downPayment, nominalInterestRate, amortization, paymentSchedule);
+    expect(errors.length).toBe(1);
+
+    const errorInfo = JSON.parse(errors[0].message).information;
+    expect(errorInfo).toBe("The paymentSchedule must be one of the following: accelerated-bi-weekly, bi-weekly, monthly. \"weekly\" was received instead.");
+  });
+});
+
+describe("Tests if the amortization is validated correctly", () => {
+  it("should return error if amortization is outside range", () => {
+    const { propertyPrice, downPayment, nominalInterestRate, paymentSchedule } = defaultValues;
+    const amortization = 35;
+
+    const errors = validate(propertyPrice, downPayment, nominalInterestRate, amortization, paymentSchedule);
+    expect(errors.length).toBe(1);
+
+    const errorInfo = JSON.parse(errors[0].message).information;
+    expect(errorInfo).toBe("The amortization must be one of the following: 5, 10, 15, 20, 25, 30 but \"35\" was received instead.");
   });
 });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -56,7 +56,7 @@ function validateAmortization(amortization: number): Error[] {
   if (isValid && !amortizations.includes(amortization)) {
     const invalidAmortizationError = getError(
       "The amortization is invalid.",
-      `The amortization value must be one of the following: ${amortizations.join(", ")} but "${amortization}" was received instead.`
+      `The amortization must be one of the following: ${amortizations.join(", ")} but "${amortization}" was received instead.`
     )
 
     errors.push(invalidAmortizationError);
@@ -72,8 +72,8 @@ function validatePaymentSchedule(paymentSchedule: string): Error[] {
 
   if (!isValid) {
     const invalidFormatError = getError(
-      "The payment schedule is invalid.",
-      `The payment schedule must be a non-null string but "${paymentSchedule}" was received instead.`
+      "The paymentSchedule is invalid.",
+      `The paymentSchedule must be a non-null string but "${paymentSchedule}" was received instead.`
     )
 
     errors.push(invalidFormatError);
@@ -81,8 +81,8 @@ function validatePaymentSchedule(paymentSchedule: string): Error[] {
 
   if (isValid && !schedules.includes(paymentSchedule)) {
     const invalidAmortizationError = getError(
-      "The payment schedule is invalid.", 
-      `The payment schedule value must be one of the following: ${schedules.join(", ")}`
+      "The paymentSchedule is invalid.", 
+      `The paymentSchedule must be one of the following: ${schedules.join(", ")}. "${paymentSchedule}" was received instead.`
     );
 
     errors.push(invalidAmortizationError);


### PR DESCRIPTION
## Changes

- Fix spacing in `fetch` example on README
- Prevent function from failing if the request body is empty.
- Add tests for `paymentSchedule` and `amortization`